### PR TITLE
Fix startWebDriver usage in cucumber example

### DIFF
--- a/packages/cucumber-example/test/server.js
+++ b/packages/cucumber-example/test/server.js
@@ -1,6 +1,6 @@
 import { startWebDriver, stopWebDriver } from 'nightwatch-api';
 
-startWebDriver('default').catch(err => console.log(err));
+startWebDriver({env: 'default'}).catch(err => console.log(err));
 
 process.once('SIGTERM', async () => {
   try {


### PR DESCRIPTION
Fixes a minor issue in the cucumber example. `startWebDriver` expects an `Object` but the example code passes a `String`.