### PR TITLE
Fix typo in file path for Step 5 in getting-started.md

### DIFF
--- a/packages/website/src/data/cucumber/intro/getting-started.md
+++ b/packages/website/src/data/cucumber/intro/getting-started.md
@@ -80,7 +80,7 @@ Scenario: Searching Google
 For Cucumber to be able to understand and execute the feature file we need to create matching step definitions for every feature step we use in our feature file. Create a step definition file under `step-definitions` folder called `google.js`.
 
 ```javascript
-// step_definitions/google.js
+// step-definitions/google.js
 
 const { client } = require('nightwatch-api');
 const { Given, Then, When } = require('cucumber');


### PR DESCRIPTION
Disclaimer: I'm new to open source contributions so if I'm missing any general knowledge/well-known conventions in the format or content of this PR, please let me know.

<hr>

This is partly in reference to #173, as I came across an error while working on that issue. I have not requested to be assigned to #173 since it's more work than I can complete in a timely fashion.

Currently, the file path commented in the code block for Step 5 in [getting-started.md](https://github.com/mucsi96/nightwatch-api/blob/master/packages/website/src/data/cucumber/intro/getting-started.md) reads:
 `step_definitions/google.js`
(underscore between `step` and `definitions`)

The 'e2e-test' script in Step 6 references a different name: 
`--require step-definitions`
(dash between `step` and `definitions`)

This PR updates the file path comment in Step 5 to `step-definitions/google.js` so that if the reader is following along verbatim (as I was), cucumber-js is able to include the step definitions from the appropriate folder.

