### PR TITLE
isWebDriverManaged no longer overrides defined selenium.start_process

### DIFF
--- a/packages/nightwatch-api/src/client.ts
+++ b/packages/nightwatch-api/src/client.ts
@@ -59,7 +59,7 @@ function createRunner(options: IOptions) {
       config: (options && options.configFile) || getDefaultConfigFile()
     });
     runner.isWebDriverManaged = function() {
-      if (this.baseSettings.selenium) {
+      if (this.baseSettings.selenium && this.baseSettings.selenium.start_process === undefined) {
         this.baseSettings.selenium.start_process = true;
       }
       return true;


### PR DESCRIPTION
When attempting to use nightwatch-api with cucumber-js using browerstack via their tutorial (https://www.browserstack.com/automate/nightwatch) I kept running in to an  issue where despite telling nighwatch not to start selenium, it was attempting to find the local selenium JAR. I tracked it down to the isWebDriverManaged which assumed that if the selenium config block was defined at all, that there was a local selenium server running. This is of course not always the case.