### PR TITLE
Point package.json typescript types to existing file

### DIFF
--- a/packages/nightwatch-api/package.json
+++ b/packages/nightwatch-api/package.json
@@ -6,7 +6,7 @@
     "lib",
     "types"
   ],
-  "types": "./lib/main.d.ts",
+  "types": "./lib/index.d.ts",
   "engines": {
     "node": ">= 8.0.0"
   },


### PR DESCRIPTION
Looks like `/lib/main.ts` was renamed to `/lib/index.ts` at some point in the past.